### PR TITLE
FIX: error when trying to delete an upload with s3 url

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -108,7 +108,9 @@ after_initialize do
 
     def compress_backup?
       @compress ||= begin
-        if FileHelper.respond_to?(:is_supported_image?)
+        if local_path.nil?
+          false
+        elsif FileHelper.respond_to?(:is_supported_image?)
           !FileHelper.is_supported_image?(File.basename(local_path))
         else
           !FileHelper.is_image?(File.basename(local_path))


### PR DESCRIPTION
Deleting a user with uploads fails because the after_destroy callback fails on uploads with an S3 url. `Discourse.store.path_for(self)` is nil, causing an error in `s3_backup_path`. Not sure if this is the correct fix though...