### PR TITLE
FIX: Handle S3 etag returned by upload method in s3_helper

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -132,7 +132,7 @@ after_initialize do
             local_path, compress: compress_backup?
           ) do |tmp_path|
 
-            path = s3_helper.upload(tmp_path, s3_backup_path)
+            path, etag = s3_helper.upload(tmp_path, s3_backup_path)
           end
 
           PluginStore.set(

--- a/spec/jobs/backup_upload_to_s3_spec.rb
+++ b/spec/jobs/backup_upload_to_s3_spec.rb
@@ -51,11 +51,13 @@ describe Jobs::BackupUploadToS3 do
   end
 
   describe '#backup_upload' do
+    let(:etag) { "ETag" }
+
     it "should store the upload on to s3" do
       DiscourseBackupUploadsToS3::FileEncryptor.any_instance.stubs(:encrypt).yields(file_from_fixtures("logo.png"))
       S3Helper.any_instance.expects(:s3_bucket).returns(s3_bucket)
       s3_bucket.expects(:object).with("default/#{upload_path}.enc").returns(s3_object)
-      s3_object.expects(:upload_file)
+      s3_object.stubs(:put).returns(Aws::S3::Types::PutObjectOutput.new(etag: etag))
 
       subject.execute(upload_id: upload.id)
 
@@ -83,7 +85,7 @@ describe Jobs::BackupUploadToS3 do
 
         S3Helper.any_instance.expects(:s3_bucket).returns(s3_bucket)
         s3_bucket.expects(:object).with("default/#{upload_path}.gz.enc").returns(s3_object)
-        s3_object.expects(:upload_file)
+        s3_object.stubs(:put).returns(Aws::S3::Types::PutObjectOutput.new(etag: etag))
 
         subject.execute(upload_id: upload.id)
 
@@ -103,7 +105,7 @@ describe Jobs::BackupUploadToS3 do
         DiscourseBackupUploadsToS3::FileEncryptor.any_instance.stubs(:encrypt).yields(file_from_fixtures("logo.png"))
         S3Helper.any_instance.expects(:s3_bucket).returns(s3_bucket)
         s3_bucket.expects(:object).with("path/default/#{upload_path}.enc").returns(s3_object)
-        s3_object.expects(:upload_file)
+        s3_object.stubs(:put).returns(Aws::S3::Types::PutObjectOutput.new(etag: etag))
 
         subject.execute(upload_id: upload.id)
 


### PR DESCRIPTION
It should be merged only after adding the etag support in core by the PR https://github.com/discourse/discourse/pull/6795