### PR TITLE
[WIP] FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/regular/backup_upload_to_s3.rb
+++ b/app/jobs/regular/backup_upload_to_s3.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class BackupUploadToS3 < Jobs::Base
+  class BackupUploadToS3 < ::Jobs::Base
     sidekiq_options queue: 'low'
 
     def execute(args)

--- a/app/jobs/regular/remove_upload_from_s3.rb
+++ b/app/jobs/regular/remove_upload_from_s3.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class RemoveUploadFromS3 < Jobs::Base
+  class RemoveUploadFromS3 < ::Jobs::Base
     sidekiq_options queue: 'low'
 
     def execute(args)

--- a/app/jobs/scheduled/backfill_uploads_backup.rb
+++ b/app/jobs/scheduled/backfill_uploads_backup.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class BackfillUploadsBackup < Jobs::Scheduled
+  class BackfillUploadsBackup < ::Jobs::Scheduled
     every 1.hour
 
     def execute(args)

--- a/app/jobs/scheduled/purge_deleted_uploads_backup.rb
+++ b/app/jobs/scheduled/purge_deleted_uploads_backup.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class PurgeDeletedUploadsBackup < Jobs::Scheduled
+  class PurgeDeletedUploadsBackup < ::Jobs::Scheduled
     every 1.day
 
     def execute(args)


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364